### PR TITLE
Fix use_server_side_encryption option

### DIFF
--- a/lib/fluent/plugin/out_s3.rb
+++ b/lib/fluent/plugin/out_s3.rb
@@ -16,7 +16,7 @@ module Fluent
 
     config_param :path, :string, :default => ""
     config_param :use_ssl, :bool, :default => true
-    config_param :use_server_side_encryption, :string, :default => nil
+    config_param :use_server_side_encryption, :bool, :default => false
     config_param :aws_key_id, :string, :default => nil, :secret => true
     config_param :aws_sec_key, :string, :default => nil, :secret => true
     config_param :aws_iam_retries, :integer, :default => 5
@@ -84,7 +84,7 @@ module Fluent
       options[:s3_endpoint] = @s3_endpoint if @s3_endpoint
       options[:proxy_uri] = @proxy_uri if @proxy_uri
       options[:use_ssl] = @use_ssl
-      options[:s3_server_side_encryption] = @use_server_side_encryption
+      options[:s3_server_side_encryption] = :aes256 if @use_server_side_encryption
 
       @s3 = AWS::S3.new(options)
       @bucket = @s3.buckets[@s3_bucket]


### PR DESCRIPTION
http://www.rubydoc.info/gems/aws-sdk-v1/AWS/Core/Configuration:s3_server_side_encryption
According to the documentation, the only valid value is :aes256.
How about changing "use_server_side_encryption" option to a bool?
